### PR TITLE
[LOG-13611-travis] Enable TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+services:
+  - docker
+


### PR DESCRIPTION
In order to enable TravisCI for PRs there needs to be a `.travis.yml` in the upstream master branch.
Adding a minimal one.